### PR TITLE
feat: dithering

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import type { Gif, UnencodedFrame } from './types'
+import type { DitherMethod, Gif, UnencodedFrame } from './types'
 
 export interface EncoderOptions extends Partial<Omit<Gif, 'width' | 'height' | 'frames'>> {
   /** GIF width */
@@ -17,4 +17,8 @@ export interface EncoderOptions extends Partial<Omit<Gif, 'width' | 'height' | '
   premultipliedAlpha?: boolean
   /** Palette tint */
   tint?: Array<number>
+  /** Specifies the dithering method to be used for colors */
+  dither?: DitherMethod
+  /** Specifies the dithering method to be used for partially transparent pixels */
+  ditherTransparency?: DitherMethod
 }

--- a/src/transformers/FrameToIndexedFrame.ts
+++ b/src/transformers/FrameToIndexedFrame.ts
@@ -1,17 +1,50 @@
-import type { QuantizedColor } from 'modern-palette'
+import type { QuantizedColor, Rgb } from 'modern-palette'
 import type { EncoderConfig } from '../Encoder'
-import type { EncodingFrame } from '../types'
+import type { DitherMethod, EncodingFrame } from '../types'
 import { Finder } from 'modern-palette'
+
+const ditherKernels: Record<DitherMethod, [number, number, number][]> = {
+  'floyd-steinberg': [
+    [7 / 16, 1, 0],
+    [3 / 16, -1, 1],
+    [5 / 16, 0, 1],
+    [1 / 16, 1, 1],
+  ],
+  'atkinson': [
+    [1 / 8, 1, 0],
+    [1 / 8, 2, 0],
+    [1 / 8, -1, 1],
+    [1 / 8, 0, 1],
+    [1 / 8, 1, 1],
+    [1 / 8, 0, 2],
+  ],
+  'stucki': [
+    [8 / 42, 1, 0],
+    [4 / 42, 2, 0],
+    [2 / 42, -2, 1],
+    [4 / 42, -1, 1],
+    [8 / 42, 0, 1],
+    [4 / 42, 1, 1],
+    [2 / 42, 2, 1],
+    [1 / 42, -2, 2],
+    [2 / 42, -1, 2],
+    [4 / 42, 0, 2],
+    [2 / 42, 1, 2],
+    [1 / 42, 2, 2],
+  ],
+}
 
 export class FrameToIndexedFrame implements ReadableWritablePair<EncodingFrame, EncodingFrame> {
   protected _rsControler!: ReadableStreamDefaultController<EncodingFrame>
   protected _finder: Finder
+  protected _colors: Array<QuantizedColor>
 
   constructor(
     protected _config: EncoderConfig,
     colors: Array<QuantizedColor>,
   ) {
     this._finder = new Finder(colors, _config.premultipliedAlpha, _config.tint)
+    this._colors = colors
   }
 
   readable = new ReadableStream<EncodingFrame>({
@@ -22,6 +55,70 @@ export class FrameToIndexedFrame implements ReadableWritablePair<EncodingFrame, 
     write: (frame) => {
       const transparentIndex = this._config.backgroundColorIndex
       const pixels = frame.data
+
+      if (frame.width && frame.height && (this._config.dither || this._config.ditherTransparency)) {
+        const pos = (x: number, y: number, c: 0 | 1 | 2 | 3): number => (y * frame.width! + x) * 4 + c
+
+        if (this._config.dither) {
+          const kernel = ditherKernels[this._config.dither]
+          for (let y = 0; y < frame.height; y++) {
+            for (let x = 0; x < frame.width; x++) {
+              const p = pos(x, y, 0)
+              const oldRGB: Rgb = {
+                r: pixels[p],
+                g: pixels[p + 1],
+                b: pixels[p + 2],
+              }
+              const newRGB = this._colors[this._finder.findNearestIndex(
+                oldRGB.r,
+                oldRGB.g,
+                oldRGB.b,
+                this._config.premultipliedAlpha ? pixels[p + 3] : 255,
+              )]!.rgb
+              const error: Rgb = {
+                r: oldRGB.r - newRGB.r,
+                g: oldRGB.g - newRGB.g,
+                b: oldRGB.b - newRGB.b,
+              }
+              pixels[p] = newRGB.r
+              pixels[p + 1] = newRGB.g
+              pixels[p + 2] = newRGB.b
+              for (const [weight, xOffset, yOffset] of kernel) {
+                const xCheck = (xOffset < 0) ? (x + xOffset >= 0) : (x + xOffset < frame.width)
+                const yCheck = (yOffset < 0) ? (y + yOffset >= 0) : (y + yOffset < frame.height)
+                if (xCheck && yCheck) {
+                  const p = pos(x + xOffset, y + yOffset, 0)
+                  pixels[p] += error.r * weight
+                  pixels[p + 1] += error.g * weight
+                  pixels[p + 2] += error.b * weight
+                }
+              }
+            }
+          }
+        }
+
+        if (this._config.ditherTransparency) {
+          const kernel = ditherKernels[this._config.ditherTransparency]
+          for (let y = 0; y < frame.height; y++) {
+            for (let x = 0; x < frame.width; x++) {
+              const p = pos(x, y, 3)
+              const oldAlpha = pixels[p]
+              const newAlpha = oldAlpha < 128 ? 0 : 255
+              const error = oldAlpha - newAlpha
+              pixels[p] = newAlpha
+              for (const [weight, xOffset, yOffset] of kernel) {
+                const xCheck = (xOffset < 0) ? (x + xOffset >= 0) : (x + xOffset < frame.width)
+                const yCheck = (yOffset < 0) ? (y + yOffset >= 0) : (y + yOffset < frame.height)
+                if (xCheck && yCheck) {
+                  const p = pos(x + xOffset, y + yOffset, 3)
+                  pixels[p] += error * weight
+                }
+              }
+            }
+          }
+        }
+      }
+
       let transparent = false
       const indexes = new Uint8ClampedArray(pixels.length / 4)
       for (let len = pixels.length, i = 0; i < len; i += 4) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,3 +102,5 @@ export interface Gif89a extends Gif87a {
 export interface Gif extends Gif89a {
   version: '89a' | '87a'
 }
+
+export type DitherMethod = 'floyd-steinberg' | 'atkinson' | 'stucki'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds support for dithering for colors and partially transparent pixels. It can solve issues like #6.

Currently, modern-gif only sets pixels with alpha=0 to transparent, so when converting images with semi-transparent areas to GIF, the semi-transparency is lost and the result is poor. Photoshop supports transparency dithering when exporting GIFs, which improves the display quality. I have implemented similar dithering feature in the PR.

Open these images in new tabs to compare.

| Source | Photoshop | modern-gif | This PR (Floyd-Steinberg) |
| - | - | - | - |
| ![](https://github.com/user-attachments/assets/d9d1bcd1-50cc-4cdf-ae40-4dcf9ab33534) | ![](https://github.com/user-attachments/assets/d755ded7-9da8-43ef-84a7-135e54c63c91) | ![](https://github.com/user-attachments/assets/0f788510-f069-4845-8ec5-243bbb03fc6b) | ![](https://github.com/user-attachments/assets/4cd490e6-5dc1-4fb7-8702-8d3819a6fb12) |

Dither kernels implemented: Floyd-Steinberg, Atkinson, Stucki.

Standard image examples:

| Source | Photoshop | modern-gif | This PR (Floyd-Steinberg) |
| - | - | - | - |
| ![](https://github.com/user-attachments/assets/590209d6-ef56-405b-8cff-26fa9b6dbee5) | ![](https://github.com/user-attachments/assets/98208d39-f40d-4c29-8dcc-30c0b8d73752) | ![](https://github.com/user-attachments/assets/8f79450f-58b3-46e5-8330-f4d116be0049) | ![](https://github.com/user-attachments/assets/3b0719e1-52b2-4c25-bd44-7534a6c7d470) |

| Source | Photoshop | modern-gif | This PR (Floyd-Steinberg) |
| - | - | - | - |
| ![](https://github.com/user-attachments/assets/6c3d7195-6fb5-44d2-a061-926fe8d413b4) | ![](https://github.com/user-attachments/assets/d2bb02b9-90c2-4458-9ec8-cdc336dc1369) | ![](https://github.com/user-attachments/assets/c01650b2-9c3f-4621-b83f-600626aa2919) | ![](https://github.com/user-attachments/assets/2102a778-c1b3-4e2f-883a-6bf7a992da77) |

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

[gif.js](https://github.com/jnordberg/gif.js) already implements dithering but for colors only. The results for images with partially transparent pixels are also poor.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Pull Request Guidelines](https://github.com/qq15725/modern-gif/blob/main/.github/pull-request-guidelines.md) and follow the [PR Title Convention](https://github.com/qq15725/modern-gif/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
