### PR TITLE
fix: read GIF sub-blocks as length-prefixed chunks

### DIFF
--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -37,10 +37,12 @@ export class Reader {
   readSubBlock(): number[] {
     const block: number[] = []
     while (true) {
-      const val = this.readByte()
-      if (val === 0 && this._view.getUint8(this.offset) !== 0)
+      const length = this.readByte()
+      if (length === 0)
         break
-      block.push(val)
+      for (let i = 0; i < length; i++) {
+        block.push(this.readByte())
+      }
     }
     return block
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,48 @@
-import { describe, expect, it } from 'vitest'
+import type { Buffer } from 'node:buffer'
+import { readdirSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { decode } from '../src/decode'
+import { Reader } from '../src/Reader'
 
-describe('should', () => {
-  it('exported', () => {
-    expect(1).toEqual(1)
+function toArrayBuffer(buffer: Buffer): ArrayBuffer {
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer
+}
+
+describe('reader.readSubBlock', () => {
+  it('reads a single length-prefixed chunk without truncating on an embedded 0x00 byte', () => {
+    // length=5, data="A\0BCD" (embeds a 0x00 mid-payload), terminator=0x00.
+    // A real GIF sub-block's data is arbitrary bytes, so 0x00 can legally
+    // appear inside it — only a 0x00 *length* byte terminates the sequence.
+    const bytes = new Uint8Array([5, 0x41, 0x00, 0x42, 0x43, 0x44, 0])
+    const reader = new Reader(bytes)
+
+    expect(reader.readSubBlock()).toEqual([0x41, 0x00, 0x42, 0x43, 0x44])
+    // Fully consumed: 1 length byte + 5 data bytes + 1 terminator byte.
+    expect(reader.offset).toBe(7)
+  })
+
+  it('reads multiple chunks in one sub-block sequence', () => {
+    // Two chunks (length=3, length=2) followed by the terminator.
+    const bytes = new Uint8Array([3, 1, 2, 3, 2, 4, 5, 0])
+    const reader = new Reader(bytes)
+
+    expect(reader.readSubBlock()).toEqual([1, 2, 3, 4, 5])
+    expect(reader.offset).toBe(8)
+  })
+})
+
+describe('decode', () => {
+  const assetsDir = resolve(__dirname, 'assets')
+
+  it.each(readdirSync(assetsDir))('parses %s without hitting an unknown block', (name) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const bytes = readFileSync(resolve(assetsDir, name))
+
+    const gif = decode(toArrayBuffer(bytes))
+
+    expect(gif.frames.length).toBeGreaterThan(0)
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
   })
 })


### PR DESCRIPTION
Fixes #9.

## What

`Reader.readSubBlock()` guessed the end of a GIF extension's data sub-blocks by scanning for a `0x00` byte followed by a non-zero byte, instead of treating each chunk as the spec's `<length-byte><that-many-data-bytes>`. A `0x00` byte legitimately occurring inside a chunk's payload (or a payload spanning more than one chunk) would make it stop early, leaving real data unconsumed and desyncing the reader for the rest of the file — surfacing downstream as spurious `Unknown block: 0x..` warnings from `decode()`, or an outright `RangeError` depending on byte layout.

## Fix

Read each chunk's length byte and consume exactly that many bytes, matching the length-prefixed loop `decode.ts` already uses correctly for image data sub-blocks.

## Tests

Replaced the placeholder `test/index.test.ts` with:
- Two direct unit tests on `Reader.readSubBlock()`: a single chunk with an embedded `0x00` byte (the exact repro from #9), and a sequence spanning multiple chunks. Both fail against `main` (one via wrong output, one via a thrown `RangeError`) and pass with the fix.
- A smoke test decoding every fixture already bundled under `test/assets/*.gif`, asserting `decode()` never logs an `Unknown block` warning. None of the existing fixtures happen to trigger this particular bug (confirmed by running them against `main` first), so this is a general regression guard rather than the reproduction itself — the two unit tests above are.

`pnpm typecheck`, `pnpm lint`, and `pnpm test` all pass.
